### PR TITLE
Refactor/get pricing

### DIFF
--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -70,15 +70,20 @@ export default (Ember.Service || Ember.Object).extend({
         pricing.giftcard(options.giftCard);
       }
 
-      pricing
-        .address({
-          country: country,
-          postal_code: postalCode
-        })
-        .tax({
-          tax_code: taxCode,
-          vat_number: vatNumber
-        })
+      if (options.country && options.postalCode) {
+        pricing.address({
+          country: options.country,
+          postal_code: options.postalCode
+        });
+
+      }
+
+      if (options.taxCode || options.vatNumber) {
+        pricing.tax({
+          tax_code: options.taxCode,
+          vat_number: options.vatNumber
+        });
+      }
 
       return pricing
         .catch(function(err){

--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -47,37 +47,27 @@ export default (Ember.Service || Ember.Object).extend({
     });
   },
 
-  getPricing: function(
-    plan,
-    planQuantity,
-    currency,
-    addons,
-    coupon,
-    giftCard,
-    country,
-    postalCode,
-    taxCode,
-    vatNumber
-    ){
-
+  /* Valid options are: plan, planQuantity, currency, addons,
+   * coupon, giftCard, country, postalCode, taxCode, vatNumber.
+   * See https://dev.recurly.com/docs/pricing#section-input-elements
+   * for more details.
+   */
+  getPricing: function(options) {
     return new Ember.RSVP.Promise(function(resolve, reject) {
-
       let pricing = recurly.Pricing()
+        .plan(options.plan, options.planQuantity)
+        .currency(options.currency)
 
-      pricing = pricing
-        .plan(plan, planQuantity)
-        .currency(currency)
-
-      addons.forEach(function (addon) {
+      options.addons.forEach(function (addon) {
         pricing.addon(addon.name, { quantity: addon.quantity });
       });
 
-      if (coupon != null) {
-        pricing.coupon(coupon);
+      if (options.coupon) {
+        pricing.coupon(options.coupon);
       }
 
-      if (giftCard != null) {
-        pricing.giftcard(giftCard);
+      if (options.giftCard) {
+        pricing.giftcard(options.giftCard);
       }
 
       pricing
@@ -89,14 +79,14 @@ export default (Ember.Service || Ember.Object).extend({
           tax_code: taxCode,
           vat_number: vatNumber
         })
+
+      return pricing
         .catch(function(err){
           reject(err);
         })
         .done(function(price){
           resolve(price)
-        })
-
-        return pricing;
-      })
+        });
+    });
   }
 });

--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -70,7 +70,7 @@ export default (Ember.Service || Ember.Object).extend({
         pricing.giftcard(options.giftCard);
       }
 
-      if (options.country && options.postalCode) {
+      if (options.country || options.postalCode) {
         pricing.address({
           country: options.country,
           postal_code: options.postalCode

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
   contentFor: function(type) {
     // we use body since Recurly must be available before
     if (type === 'body') {
-      return '<script type="text/javascript" src="https://js.recurly.com/v3/recurly.js"></script>';
+      return '<script type="text/javascript" src="https://js.recurly.com/v4/recurly.js"></script>';
     }
   }
 };


### PR DESCRIPTION
Since the majority of arguments are optional in the getPricing method, I updated it to take an object as its argument instead. This way it will be easier to pass in only the arguments we need to, like this:
```js
this.get('recurly').getPricing({
  plan: plan,
  planQuantity: 1,
  currency: this.get('currency')
});
```

I also changed the recurly.js version to the latest version: v4. 