### PR TITLE
Only configure recurly if it is defined

### DIFF
--- a/app/initializers/recurly-service.js
+++ b/app/initializers/recurly-service.js
@@ -5,7 +5,10 @@ export function initialize(container, application) {
   if(!config.recurly.publicKey) {
     throw new Ember.Error('RecurlyService: Missing Recurly key, please set `ENV.recurly.publicKey` in config.environment.js');
   }
-  recurly.configure(config.recurly.publicKey);
+
+  if (window.recurly) {
+    recurly.configure(config.recurly.publicKey);
+  }
 }
 
 export default {


### PR DESCRIPTION
If recurly fails to load for whatever reason, the error that occurs here prevents the entire interface from loading in Ember. 