### PR TITLE
Call reject callback when PayPal flow is cancelled

### DIFF
--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -42,6 +42,7 @@ export default (Ember.Service || Ember.Object).extend({
       const paypal = recurly.PayPal(options);
       paypal.on('token', resolve);
       paypal.on('error', reject);
+      paypal.on('cancel', reject);
       paypal.start(options);
     });
   },


### PR DESCRIPTION
Handle the `cancel` PayPal event. You can find more details about this event [here](https://dev.recurly.com/docs/paypal#section--cancel-).