### PR TITLE
Remove getter and setter for recurly.config.fields

### DIFF
--- a/app/services/recurly.js
+++ b/app/services/recurly.js
@@ -107,20 +107,5 @@ export default (Ember.Service || Ember.Object).extend({
     recurly.parent();
   },
 
-  config: {
-    fields: Ember.computed({
-      get() {
-        return recurly.config.fields;
-      },
-
-      set(key, value) {
-        Object.keys(value).forEach((key) => {
-          recurly.config.fields[key] = Object.assign(
-            recurly.config.fields[key], value[key]
-          );
-        });
-        return recurly.config.fields;
-      }
-    })
-  }
+  config: Ember.computed(() => recurly.config)
 });


### PR DESCRIPTION
After updating our app to Ember v3.6, the getter and setter for `recurly.config.fields` was no longer working as expected. This PR simplifies the recurly config access. Now, to change the style for recurly fields for example, just get the config object and modify it:
```js
const config = this.get('recurly.config');
config.fields.all.style = { color: 'red' };
```